### PR TITLE
Replace min_items with min_length in CreateOrderSchema due to pydanti…

### DIFF
--- a/src/orders/api/schemas.py
+++ b/src/orders/api/schemas.py
@@ -39,7 +39,7 @@ class OrderItemSchema(BaseModel):
 
 
 class CreateOrderSchema(BaseModel):
-    order: conlist(OrderItemSchema, min_items=1)
+    order: conlist(OrderItemSchema, min_length=1)
 
     class Config:
         extra = Extra.forbid


### PR DESCRIPTION
Replace min_items with min_length in CreateOrderSchema due to pydantic version update

 Changes to be committed:
	modified:   src/orders/api/schemas.py